### PR TITLE
Fix MP handthrottle sync issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Download FS25_realismAddon_gearbox.zip from the releases section and put it into
 ###### V 0.9.0.6
 
 - added binding for secondGroup gears 2 or 1, to support range splitter switches on SKRS style shiftknobs
+- fix MP sync issue, where handthrottle is set to around 50% when entering vehicles and coupling or decoupling attachments
 
 ###### V 0.9.0.5
 

--- a/realismAddon_gearbox_inputs.lua
+++ b/realismAddon_gearbox_inputs.lua
@@ -193,6 +193,10 @@ function realismAddon_gearbox_inputs.registerEventListeners(vehicleType)
 	SpecializationUtil.registerEventListener(vehicleType, "onReadUpdateStream", realismAddon_gearbox_inputs)
 
 	SpecializationUtil.registerEventListener(vehicleType, "onRegisterActionEvents", realismAddon_gearbox_inputs)
+
+	-- Listen for attach/detach to force sync
+	SpecializationUtil.registerEventListener(vehicleType, "onPostAttach", realismAddon_gearbox_inputs)
+	SpecializationUtil.registerEventListener(vehicleType, "onPreDetach", realismAddon_gearbox_inputs)
 end
 
 function realismAddon_gearbox_inputs.registerFunctions(vehicleType) end
@@ -219,6 +223,9 @@ function realismAddon_gearbox_inputs:onLoad(savegame)
 	spec.handThrottleUp = false
 
 	spec.synchHandThrottleDirtyFlag = self:getNextDirtyFlag()
+
+	-- Force sync after load
+	self:raiseDirtyFlags(spec.synchHandThrottleDirtyFlag)
 
 	-- gear shift axis values
 	spec.gearAxisPosition = 0
@@ -306,3 +313,17 @@ MotorGearShiftEvent.writeStream = Utils.overwrittenFunction(
 	MotorGearShiftEvent.writeStream,
 	realismAddon_gearbox_inputs.MotorGearShiftEvent_writeStream
 )
+
+function realismAddon_gearbox_inputs:onPostAttach(attacherVehicle, inputJointDescIndex, jointDescIndex)
+	local spec = self.spec_realismAddon_gearbox_inputs
+	if spec and spec.synchHandThrottleDirtyFlag then
+		self:raiseDirtyFlags(spec.synchHandThrottleDirtyFlag)
+	end
+end
+
+function realismAddon_gearbox_inputs:onPreDetach(attacherVehicle, implement)
+	local spec = self.spec_realismAddon_gearbox_inputs
+	if spec and spec.synchHandThrottleDirtyFlag then
+		self:raiseDirtyFlags(spec.synchHandThrottleDirtyFlag)
+	end
+end


### PR DESCRIPTION
This pull request addresses a multiplayer synchronization issue with the hand throttle in the realismAddon_gearbox mod. The main change ensures that the hand throttle state is properly synced when vehicles are entered, or attachments are coupled or decoupled, preventing it from being incorrectly set to around 50% in multiplayer sessions.

Synchronization fixes:

* Added event listeners for `onPostAttach` and `onPreDetach` in `realismAddon_gearbox_inputs.registerEventListeners` to force hand throttle sync when attachments are connected or disconnected.
* Implemented `onPostAttach` and `onPreDetach` functions to raise the hand throttle dirty flag, ensuring the throttle state is synchronized during attach/detach events.
* After loading a vehicle, force a sync of the hand throttle state by raising the appropriate dirty flag in `realismAddon_gearbox_inputs:onLoad`.

Documentation:

* Updated `README.md` to mention the fix for the multiplayer sync issue where hand throttle was incorrectly set to around 50% when entering vehicles or coupling/decoupling attachments.